### PR TITLE
Include the route's verbs if they are constrained to certain verbs

### DIFF
--- a/src/AttributeAuthorization.Tests/Properties/AssemblyInfo.cs
+++ b/src/AttributeAuthorization.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/AttributeAuthorization/AuthRoutePermissions.cs
+++ b/src/AttributeAuthorization/AuthRoutePermissions.cs
@@ -48,15 +48,17 @@ namespace AttributeAuthorization
 
             var route = FindRoute(request);
 
-            if (route != null && _routePermissions.ContainsKey(route.Route.RouteTemplate))
+            if (route != null)
             {
-                permissions = _routePermissions[route.Route.RouteTemplate];
-                result = (!permissions.Accepted.Any() && permissions.AuthNotRequired);
+                permissions = GetPermissions(route.Route, request);
+                if (permissions != null)
+                {
+                    result = (!permissions.Accepted.Any() && permissions.AuthNotRequired);
+                    return result;
+                }
             }
-            else
-            {
-                result = _shouldAllowNotDefined(request);
-            }
+            result = _shouldAllowNotDefined(request);
+
             return result;
         }
 
@@ -83,6 +85,20 @@ namespace AttributeAuthorization
                 result = propValue as IHttpRouteData;
             }
             return result;
+        }
+
+        private AuthPermissions GetPermissions(IHttpRoute route, HttpRequestMessage request)
+        {
+            string key = request.Method + ":" + route.RouteTemplate;
+            if (_routePermissions.ContainsKey(key))
+            {
+                return _routePermissions[key];
+            }
+            if (_routePermissions.ContainsKey(route.RouteTemplate))
+            {
+                return _routePermissions[route.RouteTemplate];
+            }
+            return null;
         }
     }
 }

--- a/src/AttributeAuthorization/Properties/AssemblyInfo.cs
+++ b/src/AttributeAuthorization/Properties/AssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2014 tpalmer")]
 [assembly: ComVisible(false)]
 [assembly: Guid("3b530efd-1d4d-4f0b-8d8a-99cd8f39855e")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/AttributeAuthorization/RoutePermissionsBuilder.cs
+++ b/src/AttributeAuthorization/RoutePermissionsBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Web.Http;
 using System.Web.Http.Controllers;
@@ -60,6 +61,7 @@ namespace AttributeAuthorization
                 HttpControllerDescriptor controllerDescriptor;
                 if (ExtractRouteInfo(route, out info) && FindControllerDescriptor(info, out controllerDescriptor))
                 {
+                    var mapAdditions = new Dictionary<string, AuthPermissions>();
                     var method = controllerDescriptor.ControllerType.GetMethod(info.ActionName);
 
                     bool isPublic = method.GetCustomAttributes<RequiresNoAuth>().Any() || controllerDescriptor.GetCustomAttributes<RequiresNoAuth>().Any();
@@ -67,7 +69,15 @@ namespace AttributeAuthorization
                     var accepted = method.GetCustomAttributes<RequiresAuth>().SelectMany(a => a.Expand())
                         .Concat(controllerDescriptor.GetCustomAttributes<RequiresAuth>().SelectMany(a => a.Expand()))
                         .Distinct().ToList();
-                    map.Add(route.RouteTemplate, new AuthPermissions {  AuthNotRequired = isPublic, Accepted = accepted });
+
+                    mapAdditions = GetMapForRoute(route, isPublic, accepted);
+                    foreach (var addMap in mapAdditions)
+                    {
+                        if (!map.ContainsKey(addMap.Key))
+                        {
+                            map.Add(addMap.Key, addMap.Value);
+                        }
+                    }
                 }
                 else
                 {
@@ -97,6 +107,73 @@ namespace AttributeAuthorization
             descriptor = _controllerSelector.GetControllerMapping()
                 .FirstOrDefault(s => String.Compare(s.Key, info.ControllerName, StringComparison.InvariantCultureIgnoreCase) == 0).Value;
             return descriptor != null;
+        }
+
+        private Dictionary<string, AuthPermissions> GetMapForRoute(IHttpRoute route, bool isPublic, List<string> accepted)
+        {
+            var map = new Dictionary<string, AuthPermissions>();
+
+            var authPermission = new AuthPermissions
+            {
+                AuthNotRequired = isPublic,
+                Accepted = accepted
+            };
+
+            if (route.Constraints.Count == 0)
+            {
+                map.Add(route.RouteTemplate, authPermission);
+                return map;
+            }
+
+            return GetVerbMapRoute(route, authPermission);
+        }
+
+        private Dictionary<string, AuthPermissions> GetVerbMapRoute(IHttpRoute route, AuthPermissions authPermission)
+        {
+            var map = new Dictionary<string, AuthPermissions>();
+            var constraints = GetConstraints(route);
+
+            if (constraints.Count > 0)
+            {
+                foreach (var verb in constraints)
+                {
+                    if (verb == HttpMethod.Options.Method)
+                    {
+                        continue;
+                    }
+                    var key = verb + ":" + route.RouteTemplate;
+                    map.Add(key, authPermission);
+                }
+            }
+            else
+            {
+                map.Add(route.RouteTemplate, authPermission);
+            }
+
+            return map;
+        }
+
+        private List<string> GetConstraints(IHttpRoute route)
+        {
+            var constraints = new List<string>();
+            object allowedVerbs;
+
+            if (route.Constraints.TryGetValue("inboundHttpMethod", out allowedVerbs))
+            {
+                var test = allowedVerbs.GetType();
+
+                PropertyInfo prop = test.GetProperty("AllowedMethods");
+                if (prop != null)
+                {
+                    var verbs = prop.GetValue(allowedVerbs) as IReadOnlyCollection<string> ?? new List<string>();
+                    foreach (var verb in verbs)
+                    {
+                        constraints.Add(verb);
+                    }
+                }
+            }
+
+            return constraints;
         }
     }
 }


### PR DESCRIPTION
If you have two routes with the same path, but different verbs then you will get a duplicate key exception when attempting to add the second route. This change appends the route verb/http method if it is constrained to certain http methods. If they are not constrained it should allow anything through. I believe I have preserved backwards compatibility, and added new unit tests for the verb functionality. 

I believe everything is ready to push the update to NuGet, but it was published under your account, so if you want to push the update that would be great! Otherwise I can look at publishing myself. 